### PR TITLE
William abandoned the repo

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -2,10 +2,11 @@ h2. git-wtf
 
 h3. Maintenance
 
-Current (?) known maintainer: William Morgan
+Current known maintainer: Daniel Vartanov
+Githup repository: https://github.com/DanielVartanov/willgit
 Information page: http://git-wt-commit.rubyforge.org/#git-wtf
-Gitorious repository: https://gitorious.org/willgit/mainline
-Homebrew formula: https://github.com/mxcl/homebrew/blob/master/Library/Formula/willgit.rb 
+Gitorious repository: https://gitorious.org/willgit/mainline (abandoned by William)
+Homebrew formula: https://github.com/mxcl/homebrew/blob/master/Library/Formula/willgit.rb
 (installation through homebrew is apparently supported)
 
-<code>git-wtf</code> is not maintained here. The last known and maintained version of <code>git-wtf</code> can be found on gitorious. Pull requests and issues should be sent to the main repository.
+<code>git-wtf</code> is not maintained here. The last known and maintained version of <code>git-wtf</code> can be found [here](https://github.com/DanielVartanov/willgit). Pull requests and issues should be sent to the main repository.


### PR DESCRIPTION
Gitorious is going to die soon. William confirmed over email that he would just let it die and let me mirror it to github. New repo is here now: https://github.com/DanielVartanov/willgit